### PR TITLE
Upgrade to FontAwesome 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ To add to the 'Tools & Resources' page, you should only have to edit the `_data/
 
 You can either choose a FontAwesome font (see "EV-D68 Reference Converter"), or add a (very small) image to `/assets/images/icons` and use this instead (see "EV-D68 Nextstrain Build"). 
 
+### FontAwesome notes
+
+Throughout the site we often make use of 'FontAwesome' icons for links and for decorating cards, menus, and etc. We used (pre Aug 2025) to use FontAwesome 4.7 (list of icons [here](https://fontawesome.com/v4/icons/)) - as of 4 Aug 2025, we've moved to FontAwesome 6.5.2 (see `_layouts/default.html`). Note that we do not have Pro - only the basic icon set. To add a new icon, see [this list](https://fontawesome.com/v6/search) to see what's available.
+
 ## To Do list:
 
 - [x] Set real pictures for all projects

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -6,6 +6,7 @@
   bluesky: 'https://bsky.app/profile/firefoxx66.bsky.social'
   orcid: 'https://orcid.org/0000-0002-0078-2212'
   gscholar: 'https://scholar.google.com/citations?user=ZaupG3YAAAAJ&hl=en'
+  mastodon: 'https://mstdn.science/@firefoxx66'
   link: /people/emma-hodcroft/
   interests:
     - Being engrossed in a fascinating book

--- a/_includes/person_card.html
+++ b/_includes/person_card.html
@@ -15,22 +15,25 @@
   
         <ul class="team-social d-flex justify-content-center list-unstyled mb-0">
           {% if include.person.twitter %}
-            <li class="mx-1"><a href="{{ include.person.twitter }}"><i class="fa fa-twitter-square fa-lg"></i></a></li>
+            <li class="mx-1"><a href="{{ include.person.twitter }}"><i class="fa-brands fa-twitter fa-lg"></i></a></li>
           {% endif %}
           {% if include.person.bluesky %}
-            <li class="mx-1"><a href="{{ include.person.bluesky }}"><i class="fa fa-skyatlas fa-lg"></i></a></li>
+            <li class="mx-1"><a href="{{ include.person.bluesky }}"><i class="fa fa-brands fa-bluesky fa-lg"></i></a></li>
+          {% endif %}
+          {% if include.person.mastodon %}
+            <li class="mx-1"><a href="{{ include.person.mastodon }}"><i class="fa-brands fa-mastodon fa-lg"></i></a></li>
           {% endif %}
           {% if include.person.facebook %}
-            <li class="mx-1"><a href="{{ include.person.facebook }}"><i class="fa fa-facebook-official fa-lg"></i></a></li>
+            <li class="mx-1"><a href="{{ include.person.facebook }}"><i class="fa-brands fa-facebook fa-lg"></i></a></li>
           {% endif %}
           {% if include.person.linkedin %}
-            <li class="mx-1"><a href="{{ include.person.linkedin }}"><i class="fa fa-linkedin-square fa-lg"></i></a></li>
+            <li class="mx-1"><a href="{{ include.person.linkedin }}"><i class="fa-brands fa-linkedin-in fa-lg"></i></a></li>
           {% endif %}
           {% if include.person.github %}
-            <li class="mx-1"><a href="{{ include.person.github }}"><i class="fa fa-github-square fa-lg"></i></a></li>
+            <li class="mx-1"><a href="{{ include.person.github }}"><i class="fa-brands fa-github fa-lg"></i></a></li>
           {% endif %}
           {% if include.person.orcid %}
-            <li class="mx-1"><a href="{{ include.person.orcid }}"><i class="fa fa-leaf fa-lg"></i></a></li>
+            <li class="mx-1"><a href="{{ include.person.orcid }}"><i class="fa-brands fa-orcid fa-lg"></i></a></li>
           {% endif %}
         </ul>
       </div>

--- a/_includes/share-buttons.html
+++ b/_includes/share-buttons.html
@@ -5,22 +5,22 @@
 			<a class="f nostyle" href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url }}"
 				onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-facebook-official fa"></i></a>
+					class="fa-brands fa-facebook fa"></i></a>
 			<a class="t nostyle" href="https://twitter.com/intent/tweet?text=&url={{ page.url | absolute_url }}"
 				onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-twitter fa"></i></a>
+					class="fa-brands fa-twitter fa"></i></a>
 			<a class="g nostyle" href="https://plus.google.com/share?url={{ page.url | absolute_url }}" onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-google-plus fa"></i></a>
+					class="fa-brands fa-google-plus-g fa"></i></a>
 			<a class="r nostyle" href="http://www.reddit.com/submit?url={{ page.url | absolute_url }}" onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=900,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-reddit fa"></i></a>
+					class="fa-brands fa-reddit-alien fa"></i></a>
 			<a class="l nostyle"
 				href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}&title=&summary=&source=webjeda"
 				onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-linkedin fa"></i></a>
+					class="fa-brands fa-linkedin-in fa"></i></a>
 			<a class="e nostyle"
 				href="mailto:?subject=&amp;body=Check&amp;out&amp;this&amp;site&amp;{{ page.url | absolute_url }}"><i
 					class="fa fa-envelope fa"></i></a>

--- a/_includes/share-buttons.html
+++ b/_includes/share-buttons.html
@@ -10,9 +10,10 @@
 				onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
 					class="fa-brands fa-twitter fa"></i></a>
-			<a class="g nostyle" href="https://plus.google.com/share?url={{ page.url | absolute_url }}" onclick="window.open(this.href, 'mywin',
-            'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa-brands fa-google-plus-g fa"></i></a>
+			<a class="b nostyle" href="https://bsky.app/intent/compose?text={{ page.url | absolute_url | uri_escape }}"
+				onclick="window.open(this.href, 'mywin',
+				'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i 
+				class="fa-brands fa-bluesky fa"></i></a>
 			<a class="r nostyle" href="http://www.reddit.com/submit?url={{ page.url | absolute_url }}" onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=900,height=500,toolbar=1,resizable=0'); return false;"><i
 					class="fa-brands fa-reddit-alien fa"></i></a>

--- a/_includes/team-preview.html
+++ b/_includes/team-preview.html
@@ -16,22 +16,25 @@
                 <p class="position"><small>{{ item.designation }}</small></p>
                 <ul class="team-social list-inline mt-2">
                   {% if item.twitter %}
-                    <li class="list-inline-item"><a href="{{ item.twitter }}"><i class="fa fa-twitter-square fa"></i></a></li>
+                    <li class="list-inline-item"><a href="{{ item.twitter }}"><i class="fa-brands fa-twitter fa"></i></a></li>
                   {% endif %}
                   {% if item.bluesky %}
-                    <li class="list-inline-item"><a href="{{ item.bluesky }}"><i class="fa fa-skyatlas fa"></i></a></li>
+                    <li class="list-inline-item"><a href="{{ item.bluesky }}"><i class="fa-brands fa-bluesky fa"></i></a></li>
                   {% endif %}
                   {% if item.facebook %}
-                    <li class="list-inline-item"><a href="{{ item.facebook }}"><i class="fa fa-facebook-official fa"></i></a></li>
+                    <li class="list-inline-item"><a href="{{ item.facebook }}"><i class="fa-brands fa-facebook fa"></i></a></li>
+                  {% endif %}
+                  {% if item.mastodon %}
+                    <li class="list-inline-item"><a href="{{ item.mastodon }}"><i class="fa-brands fa-mastodon fa"></i></a></li>
                   {% endif %}
                   {% if item.linkedin %}
-                    <li class="list-inline-item"><a href="{{ item.linkedin }}"><i class="fa fa-linkedin-square fa"></i></a></li>
+                    <li class="list-inline-item"><a href="{{ item.linkedin }}"><i class="fa-brands fa-linkedin-in fa"></i></a></li>
                   {% endif %}
                   {% if item.github %}
-                    <li class="list-inline-item"><a href="{{ item.github }}"><i class="fa fa-github-square fa"></i></a></li>
+                    <li class="list-inline-item"><a href="{{ item.github }}"><i class="fa-brands fa-github fa"></i></a></li>
                   {% endif %}
                   {% if item.orcid %}
-                    <li class="list-inline-item"><a href="{{ item.orcid }}"><i class="fa fa-leaf fa"></i></a></li>
+                    <li class="list-inline-item"><a href="{{ item.orcid }}"><i class="fa-brands fa-orcid fa"></i></a></li>
                   {% endif %}
                 </ul>
               </a>

--- a/_includes/tool_card.html
+++ b/_includes/tool_card.html
@@ -21,7 +21,7 @@
 	{% endif %}
 		{% if include.tool.github %}
 			<a href="{{ include.tool.github }}" class="btn btn-outline-secondary" target="_blank" rel="noopener">
-			<i class="fa fa-github me-1"></i> View on GitHub
+			<i class="fa-brands fa-github me-1"></i> View on GitHub
 			</a>
 		{% endif %}
     </div>

--- a/_layouts/collaboration.html
+++ b/_layouts/collaboration.html
@@ -11,7 +11,7 @@ title: Collaboration
 
 				{% if page.start_date %}
 				<p>
-				<i class="fa fa-calendar" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
+				<i class="fa-regular fa-calendar-days" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
 				<strong>Duration:</strong>
 				<span>
 					{% if page.end_date %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,7 +37,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -25,19 +25,22 @@ layout: default
         {% endif %}
         <ul class="team-social profile-social">
           {% if person.twitter %}
-          <li><a href="{{ person.twitter }}"><i class="fa fa-twitter-square fa"></i></a></li>
+          <li><a href="{{ person.twitter }}"><i class="fa-brands fa-twitter fa"></i></a></li>
           {% endif %}
           {% if person.github %}
-          <li><a href="{{ person.github }}"><i class="fa fa-github-square fa"></i></a></li>
+          <li><a href="{{ person.github }}"><i class="fa-brands fa-github fa"></i></a></li>
+          {% endif %}
+          {% if person.mastodon %}
+          <li><a href="{{ person.mastodon }}"><i class="fa-brands fa-mastodon fa"></i></a></li>
           {% endif %}
           {% if person.linkedin %}
-          <li><a href="{{ person.linkedin }}"><i class="fa fa-linkedin-square fa"></i></a></li>
+          <li><a href="{{ person.linkedin }}"><i class="fa-brands fa-linkedin-in fa"></i></a></li>
           {% endif %}
           {% if person.bluesky %}
-          <li><a href="{{ person.bluesky }}"><i class="fa fa-skyatlas fa"></i></a></li>
+          <li><a href="{{ person.bluesky }}"><i class="fa-brands fa-bluesky fa"></i></a></li>
           {% endif %}
           {% if person.orcid %}
-          <li><a href="{{ person.orcid }}"><i class="fa fa-leaf fa"></i></a></li>
+          <li><a href="{{ person.orcid }}"><i class="fa-brands fa-orcid fa"></i></a></li>
           {% endif %}
         </ul>
       </div>
@@ -95,7 +98,7 @@ layout: default
           <div class="d-flex justify-content-center flex-wrap gap-2">
             {% if person.orcid %}
               <a href="{{ person.orcid }}" class="btn btn-outline-info" style="color: #2c7eca; margin-right: 10px;" target="_blank" rel="noopener noreferrer">
-                <i class="fa fa-leaf"></i> ORCID
+                <i class="fa-brands fa-orcid"></i> ORCID
               </a>
             {% endif %}
             {% if person.gscholar %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,7 +23,7 @@ This layout is used for posts. Changing anything here will affect all posts(not 
           <div class="col-md-12 meta">
             <p><small>
                 <span>
-                  <i class="fa fa-calendar" aria-hidden="true"></i> {{page.date | date_to_string }}&nbsp;
+                  <i class="fa-regular fa-calendar-days" aria-hidden="true"></i> {{page.date | date_to_string }}&nbsp;
                 </span>
                 {% assign author_slug = page.author %}
                 {% assign author_obj = site.people | where: "slug", author_slug | first %}
@@ -37,7 +37,7 @@ This layout is used for posts. Changing anything here will affect all posts(not 
                   {% endif %}
                 </span>
                 <span>
-                  <i class="fa fa-clock-o" aria-hidden="true"></i> {% include reading-time.html %}
+                  <i class="fa-regular fa-clock" aria-hidden="true"></i> {% include reading-time.html %}
                 </span>
               </small></p>
           </div>

--- a/_pages/about.html
+++ b/_pages/about.html
@@ -36,22 +36,25 @@ desctiption: "EVE Lab is a computational biology lab that uses phylogenetics to 
           <p class="position"><small>{{item.designation}}</small></p>
           <ul class="team-social">
             {% if item.twitter %}
-            <li><a href="{{item.twitter}}"><i class="fa fa-twitter-square fa"></i></a></li>
+            <li><a href="{{item.twitter}}"><i class="fa-brands fa-twitter fa"></i></a></li>
             {% endif %}
             {% if item.bluesky %}
-            <li><a href="{{item.bluesky}}"><i class="fa fa-skyatlas fa"></i></a></li>
+            <li><a href="{{item.bluesky}}"><i class="fa-brands fa-bluesky fa"></i></a></li>
+            {% endif %}
+            {% if item.mastodon %}
+            <li><a href="{{item.mastodon}}"><i class="fa-brands fa-mastodon fa"></i></a></li>
             {% endif %}
             {% if item.facebook %}
-            <li><a href="{{item.facebook}}"><i class="fa fa-facebook-official fa"></i></a></li>
+            <li><a href="{{item.facebook}}"><i class="fa-brands fa-facebook fa"></i></a></li>
             {% endif %}
             {% if item.linkedin %}
-            <li><a href="{{item.linkedin}}"><i class="fa fa-linkedin-square fa"></i></a></li>
+            <li><a href="{{item.linkedin}}"><i class="fa-brands fa-linkedin-in fa"></i></a></li>
             {% endif %}
             {% if item.github %}
-            <li><a href="{{item.github}}"><i class="fa fa-github-square fa"></i></a></li>
+            <li><a href="{{item.github}}"><i class="fa-brands fa-github fa"></i></a></li>
             {% endif %}
             {% if item.orcid %}
-            <li><a href="{{item.orcid}}"><i class="fa fa-leaf fa"></i></a></li>
+            <li><a href="{{item.orcid}}"><i class="fa-brands fa-orcid fa"></i></a></li>
             {% endif %}
           </ul>
         </a>

--- a/docs/404.html
+++ b/docs/404.html
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,6 +135,10 @@ To add to the 'Tools & Resources' page, you should only have to edit the `_data/
 
 You can either choose a FontAwesome font (see "EV-D68 Reference Converter"), or add a (very small) image to `/assets/images/icons` and use this instead (see "EV-D68 Nextstrain Build"). 
 
+### FontAwesome notes
+
+Throughout the site we often make use of 'FontAwesome' icons for links and for decorating cards, menus, and etc. We used (pre Aug 2025) to use FontAwesome 4.7 (list of icons [here](https://fontawesome.com/v4/icons/)) - as of 4 Aug 2025, we've moved to FontAwesome 6.5.2 (see `_layouts/default.html`). Note that we do not have Pro - only the basic icon set. To add a new icon, see [this list](https://fontawesome.com/v6/search) to see what's available.
+
 ## To Do list:
 
 - [x] Set real pictures for all projects

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -35,7 +35,7 @@
 <meta name="twitter:card" content="summary" />
 <meta property="twitter:title" content="About" />
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"WebSite","author":{"@type":"Person","name":"Emma Hodcroft"},"dateModified":"2025-04-21T16:09:20+02:00","description":"EVE - Epidemiology and Virus Evolution - the Hodcroft lab","headline":"About","name":"EVE","url":"https://hodcroftlab.github.io/hodcroftlab/about/"}</script>
+{"@context":"https://schema.org","@type":"WebSite","author":{"@type":"Person","name":"Emma Hodcroft"},"dateModified":"2025-08-04T17:12:34+02:00","description":"EVE - Epidemiology and Virus Evolution - the Hodcroft lab","headline":"About","name":"EVE","url":"https://hodcroftlab.github.io/hodcroftlab/about/"}</script>
 <!-- End Jekyll SEO tag -->
  
     <meta property="og:image" content="https://hodcroftlab.github.io/assets/images/eve-cover.png" />
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -354,18 +354,21 @@ Making any change will effect all the pages(not posts) -->
           <p class="position"><small>Professor, Principal Investigator</small></p>
           <ul class="team-social">
             
-            <li><a href="https://twitter.com/firefoxx66"><i class="fa fa-twitter-square fa"></i></a></li>
+            <li><a href="https://twitter.com/firefoxx66"><i class="fa-brands fa-twitter fa"></i></a></li>
             
             
-            <li><a href="https://bsky.app/profile/firefoxx66.bsky.social"><i class="fa fa-skyatlas fa"></i></a></li>
+            <li><a href="https://bsky.app/profile/firefoxx66.bsky.social"><i class="fa-brands fa-bluesky fa"></i></a></li>
+            
+            
+            <li><a href="https://mstdn.science/@firefoxx66"><i class="fa-brands fa-mastodon fa"></i></a></li>
             
             
             
             
-            <li><a href="https://github.com/hodcroftlab"><i class="fa fa-github-square fa"></i></a></li>
+            <li><a href="https://github.com/hodcroftlab"><i class="fa-brands fa-github fa"></i></a></li>
             
             
-            <li><a href="https://orcid.org/0000-0002-0078-2212"><i class="fa fa-leaf fa"></i></a></li>
+            <li><a href="https://orcid.org/0000-0002-0078-2212"><i class="fa-brands fa-orcid fa"></i></a></li>
             
           </ul>
         </a>
@@ -382,13 +385,14 @@ Making any change will effect all the pages(not posts) -->
             
             
             
-            <li><a href="https://www.linkedin.com/in/nadia-neuner-jehle"><i class="fa fa-linkedin-square fa"></i></a></li>
+            
+            <li><a href="https://www.linkedin.com/in/nadia-neuner-jehle"><i class="fa-brands fa-linkedin-in fa"></i></a></li>
             
             
-            <li><a href="https://github.com/nneune"><i class="fa fa-github-square fa"></i></a></li>
+            <li><a href="https://github.com/nneune"><i class="fa-brands fa-github fa"></i></a></li>
             
             
-            <li><a href="https://orcid.org/0009-0001-6829-6448"><i class="fa fa-leaf fa"></i></a></li>
+            <li><a href="https://orcid.org/0009-0001-6829-6448"><i class="fa-brands fa-orcid fa"></i></a></li>
             
           </ul>
         </a>
@@ -402,18 +406,19 @@ Making any change will effect all the pages(not posts) -->
           <p class="position"><small>PhD student</small></p>
           <ul class="team-social">
             
-            <li><a href="https://twitter.com/nosi_msomi"><i class="fa fa-twitter-square fa"></i></a></li>
+            <li><a href="https://twitter.com/nosi_msomi"><i class="fa-brands fa-twitter fa"></i></a></li>
             
             
             
             
-            <li><a href="https://www.linkedin.com/in/nosihlesmsomi"><i class="fa fa-linkedin-square fa"></i></a></li>
+            
+            <li><a href="https://www.linkedin.com/in/nosihlesmsomi"><i class="fa-brands fa-linkedin-in fa"></i></a></li>
             
             
-            <li><a href="https://github.com/Nosi-Msomi"><i class="fa fa-github-square fa"></i></a></li>
+            <li><a href="https://github.com/Nosi-Msomi"><i class="fa-brands fa-github fa"></i></a></li>
             
             
-            <li><a href="https://orcid.org/0000-0003-0053-0928"><i class="fa fa-leaf fa"></i></a></li>
+            <li><a href="https://orcid.org/0000-0003-0053-0928"><i class="fa-brands fa-orcid fa"></i></a></li>
             
           </ul>
         </a>
@@ -427,16 +432,17 @@ Making any change will effect all the pages(not posts) -->
           <p class="position"><small>PhD student</small></p>
           <ul class="team-social">
             
-            <li><a href="https://twitter.com/st_keno"><i class="fa fa-twitter-square fa"></i></a></li>
+            <li><a href="https://twitter.com/st_keno"><i class="fa-brands fa-twitter fa"></i></a></li>
             
             
             
             
             
-            <li><a href="https://github.com/kstrotjohann"><i class="fa fa-github-square fa"></i></a></li>
+            
+            <li><a href="https://github.com/kstrotjohann"><i class="fa-brands fa-github fa"></i></a></li>
             
             
-            <li><a href="https://orcid.org/0009-0003-3675-3039"><i class="fa fa-leaf fa"></i></a></li>
+            <li><a href="https://orcid.org/0009-0003-3675-3039"><i class="fa-brands fa-orcid fa"></i></a></li>
             
           </ul>
         </a>
@@ -455,6 +461,7 @@ Making any change will effect all the pages(not posts) -->
             
             
             
+            
           </ul>
         </a>
       </div>
@@ -466,6 +473,7 @@ Making any change will effect all the pages(not posts) -->
           <h4 class="name">Nema Ahmed Alfaki</h4>
           <p class="position"><small>MSc student</small></p>
           <ul class="team-social">
+            
             
             
             

--- a/docs/blog/ARTIC2-open-position/index.html
+++ b/docs/blog/ARTIC2-open-position/index.html
@@ -51,7 +51,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -337,7 +337,7 @@ This layout is used for posts. Changing anything here will affect all posts(not 
           <div class="col-md-12 meta">
             <p><small>
                 <span>
-                  <i class="fa fa-calendar" aria-hidden="true"></i> 25 Jul 2025&nbsp;
+                  <i class="fa-regular fa-calendar-days" aria-hidden="true"></i> 25 Jul 2025&nbsp;
                 </span>
                 
                 
@@ -349,7 +349,7 @@ This layout is used for posts. Changing anything here will affect all posts(not 
                   
                 </span>
                 <span>
-                  <i class="fa fa-clock-o" aria-hidden="true"></i>  1 min read.
+                  <i class="fa-regular fa-clock" aria-hidden="true"></i>  1 min read.
                 </span>
               </small></p>
           </div>
@@ -401,22 +401,23 @@ We welcome diverse and international applicants!</p>
 			<a class="f nostyle" href="https://www.facebook.com/sharer/sharer.php?u=https://hodcroftlab.github.io/hodcroftlab/blog/ARTIC2-open-position/"
 				onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-facebook-official fa"></i></a>
+					class="fa-brands fa-facebook fa"></i></a>
 			<a class="t nostyle" href="https://twitter.com/intent/tweet?text=&url=https://hodcroftlab.github.io/hodcroftlab/blog/ARTIC2-open-position/"
 				onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-twitter fa"></i></a>
-			<a class="g nostyle" href="https://plus.google.com/share?url=https://hodcroftlab.github.io/hodcroftlab/blog/ARTIC2-open-position/" onclick="window.open(this.href, 'mywin',
-            'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-google-plus fa"></i></a>
+					class="fa-brands fa-twitter fa"></i></a>
+			<a class="b nostyle" href="https://bsky.app/intent/compose?text=https://hodcroftlab.github.io/hodcroftlab/blog/ARTIC2-open-position/"
+				onclick="window.open(this.href, 'mywin',
+				'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i 
+				class="fa-brands fa-bluesky fa"></i></a>
 			<a class="r nostyle" href="http://www.reddit.com/submit?url=https://hodcroftlab.github.io/hodcroftlab/blog/ARTIC2-open-position/" onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=900,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-reddit fa"></i></a>
+					class="fa-brands fa-reddit-alien fa"></i></a>
 			<a class="l nostyle"
 				href="https://www.linkedin.com/shareArticle?mini=true&url=https://hodcroftlab.github.io/hodcroftlab/blog/ARTIC2-open-position/&title=&summary=&source=webjeda"
 				onclick="window.open(this.href, 'mywin',
             'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i
-					class="fa fa-linkedin fa"></i></a>
+					class="fa-brands fa-linkedin-in fa"></i></a>
 			<a class="e nostyle"
 				href="mailto:?subject=&amp;body=Check&amp;out&amp;this&amp;site&amp;https://hodcroftlab.github.io/hodcroftlab/blog/ARTIC2-open-position/"><i
 					class="fa fa-envelope fa"></i></a>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/collaborations/artic2/index.html
+++ b/docs/collaborations/artic2/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -309,7 +309,7 @@ galite.UA = 'UA-92266803-2';
 
 				
 				<p>
-				<i class="fa fa-calendar" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
+				<i class="fa-regular fa-calendar-days" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
 				<strong>Duration:</strong>
 				<span>
 					

--- a/docs/collaborations/cpb/index.html
+++ b/docs/collaborations/cpb/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -309,7 +309,7 @@ galite.UA = 'UA-92266803-2';
 
 				
 				<p>
-				<i class="fa fa-calendar" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
+				<i class="fa-regular fa-calendar-days" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
 				<strong>Duration:</strong>
 				<span>
 					

--- a/docs/collaborations/enpen/index.html
+++ b/docs/collaborations/enpen/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -309,7 +309,7 @@ galite.UA = 'UA-92266803-2';
 
 				
 				<p>
-				<i class="fa fa-calendar" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
+				<i class="fa-regular fa-calendar-days" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
 				<strong>Duration:</strong>
 				<span>
 					

--- a/docs/collaborations/escape/index.html
+++ b/docs/collaborations/escape/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -309,7 +309,7 @@ galite.UA = 'UA-92266803-2';
 
 				
 				<p>
-				<i class="fa fa-calendar" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
+				<i class="fa-regular fa-calendar-days" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
 				<strong>Duration:</strong>
 				<span>
 					

--- a/docs/collaborations/index.html
+++ b/docs/collaborations/index.html
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/collaborations/pathoplexus/index.html
+++ b/docs/collaborations/pathoplexus/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -309,7 +309,7 @@ galite.UA = 'UA-92266803-2';
 
 				
 				<p>
-				<i class="fa fa-calendar" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
+				<i class="fa-regular fa-calendar-days" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
 				<strong>Duration:</strong>
 				<span>
 					

--- a/docs/collaborations/vim/index.html
+++ b/docs/collaborations/vim/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -309,7 +309,7 @@ galite.UA = 'UA-92266803-2';
 
 				
 				<p>
-				<i class="fa fa-calendar" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
+				<i class="fa-regular fa-calendar-days" aria-hidden="true" style="font-size: 0.95em; margin-right: 0.3rem; vertical-align: middle; color: #888;"></i>
 				<strong>Duration:</strong>
 				<span>
 					

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,7 +52,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -364,18 +364,21 @@ You can edit them there.
                 <p class="position"><small>Professor, Principal Investigator</small></p>
                 <ul class="team-social list-inline mt-2">
                   
-                    <li class="list-inline-item"><a href="https://twitter.com/firefoxx66"><i class="fa fa-twitter-square fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://twitter.com/firefoxx66"><i class="fa-brands fa-twitter fa"></i></a></li>
                   
                   
-                    <li class="list-inline-item"><a href="https://bsky.app/profile/firefoxx66.bsky.social"><i class="fa fa-skyatlas fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://bsky.app/profile/firefoxx66.bsky.social"><i class="fa-brands fa-bluesky fa"></i></a></li>
                   
                   
                   
+                    <li class="list-inline-item"><a href="https://mstdn.science/@firefoxx66"><i class="fa-brands fa-mastodon fa"></i></a></li>
                   
-                    <li class="list-inline-item"><a href="https://github.com/hodcroftlab"><i class="fa fa-github-square fa"></i></a></li>
                   
                   
-                    <li class="list-inline-item"><a href="https://orcid.org/0000-0002-0078-2212"><i class="fa fa-leaf fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://github.com/hodcroftlab"><i class="fa-brands fa-github fa"></i></a></li>
+                  
+                  
+                    <li class="list-inline-item"><a href="https://orcid.org/0000-0002-0078-2212"><i class="fa-brands fa-orcid fa"></i></a></li>
                   
                 </ul>
               </a>
@@ -393,13 +396,14 @@ You can edit them there.
                   
                   
                   
-                    <li class="list-inline-item"><a href="https://www.linkedin.com/in/nadia-neuner-jehle"><i class="fa fa-linkedin-square fa"></i></a></li>
+                  
+                    <li class="list-inline-item"><a href="https://www.linkedin.com/in/nadia-neuner-jehle"><i class="fa-brands fa-linkedin-in fa"></i></a></li>
                   
                   
-                    <li class="list-inline-item"><a href="https://github.com/nneune"><i class="fa fa-github-square fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://github.com/nneune"><i class="fa-brands fa-github fa"></i></a></li>
                   
                   
-                    <li class="list-inline-item"><a href="https://orcid.org/0009-0001-6829-6448"><i class="fa fa-leaf fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://orcid.org/0009-0001-6829-6448"><i class="fa-brands fa-orcid fa"></i></a></li>
                   
                 </ul>
               </a>
@@ -414,18 +418,19 @@ You can edit them there.
                 <p class="position"><small>PhD student</small></p>
                 <ul class="team-social list-inline mt-2">
                   
-                    <li class="list-inline-item"><a href="https://twitter.com/nosi_msomi"><i class="fa fa-twitter-square fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://twitter.com/nosi_msomi"><i class="fa-brands fa-twitter fa"></i></a></li>
                   
                   
                   
                   
-                    <li class="list-inline-item"><a href="https://www.linkedin.com/in/nosihlesmsomi"><i class="fa fa-linkedin-square fa"></i></a></li>
+                  
+                    <li class="list-inline-item"><a href="https://www.linkedin.com/in/nosihlesmsomi"><i class="fa-brands fa-linkedin-in fa"></i></a></li>
                   
                   
-                    <li class="list-inline-item"><a href="https://github.com/Nosi-Msomi"><i class="fa fa-github-square fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://github.com/Nosi-Msomi"><i class="fa-brands fa-github fa"></i></a></li>
                   
                   
-                    <li class="list-inline-item"><a href="https://orcid.org/0000-0003-0053-0928"><i class="fa fa-leaf fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://orcid.org/0000-0003-0053-0928"><i class="fa-brands fa-orcid fa"></i></a></li>
                   
                 </ul>
               </a>
@@ -440,16 +445,17 @@ You can edit them there.
                 <p class="position"><small>PhD student</small></p>
                 <ul class="team-social list-inline mt-2">
                   
-                    <li class="list-inline-item"><a href="https://twitter.com/st_keno"><i class="fa fa-twitter-square fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://twitter.com/st_keno"><i class="fa-brands fa-twitter fa"></i></a></li>
                   
                   
                   
                   
                   
-                    <li class="list-inline-item"><a href="https://github.com/kstrotjohann"><i class="fa fa-github-square fa"></i></a></li>
+                  
+                    <li class="list-inline-item"><a href="https://github.com/kstrotjohann"><i class="fa-brands fa-github fa"></i></a></li>
                   
                   
-                    <li class="list-inline-item"><a href="https://orcid.org/0009-0003-3675-3039"><i class="fa fa-leaf fa"></i></a></li>
+                    <li class="list-inline-item"><a href="https://orcid.org/0009-0003-3675-3039"><i class="fa-brands fa-orcid fa"></i></a></li>
                   
                 </ul>
               </a>
@@ -469,6 +475,7 @@ You can edit them there.
                   
                   
                   
+                  
                 </ul>
               </a>
             </div>
@@ -481,6 +488,7 @@ You can edit them there.
                 <h4 class="name mt-2">Nema Ahmed Alfaki</h4>
                 <p class="position"><small>MSc student</small></p>
                 <ul class="team-social list-inline mt-2">
+                  
                   
                   
                   

--- a/docs/people/alejandra-gonzalez/index.html
+++ b/docs/people/alejandra-gonzalez/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -336,6 +336,7 @@ galite.UA = 'UA-92266803-2';
         />
         
         <ul class="team-social profile-social">
+          
           
           
           

--- a/docs/people/emma-hodcroft/index.html
+++ b/docs/people/emma-hodcroft/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -337,17 +337,20 @@ galite.UA = 'UA-92266803-2';
         
         <ul class="team-social profile-social">
           
-          <li><a href="https://twitter.com/firefoxx66"><i class="fa fa-twitter-square fa"></i></a></li>
+          <li><a href="https://twitter.com/firefoxx66"><i class="fa-brands fa-twitter fa"></i></a></li>
           
           
-          <li><a href="https://github.com/hodcroftlab"><i class="fa fa-github-square fa"></i></a></li>
+          <li><a href="https://github.com/hodcroftlab"><i class="fa-brands fa-github fa"></i></a></li>
+          
+          
+          <li><a href="https://mstdn.science/@firefoxx66"><i class="fa-brands fa-mastodon fa"></i></a></li>
           
           
           
-          <li><a href="https://bsky.app/profile/firefoxx66.bsky.social"><i class="fa fa-skyatlas fa"></i></a></li>
+          <li><a href="https://bsky.app/profile/firefoxx66.bsky.social"><i class="fa-brands fa-bluesky fa"></i></a></li>
           
           
-          <li><a href="https://orcid.org/0000-0002-0078-2212"><i class="fa fa-leaf fa"></i></a></li>
+          <li><a href="https://orcid.org/0000-0002-0078-2212"><i class="fa-brands fa-orcid fa"></i></a></li>
           
         </ul>
       </div>
@@ -404,7 +407,7 @@ galite.UA = 'UA-92266803-2';
           <div class="d-flex justify-content-center flex-wrap gap-2">
             
               <a href="https://orcid.org/0000-0002-0078-2212" class="btn btn-outline-info" style="color: #2c7eca; margin-right: 10px;" target="_blank" rel="noopener noreferrer">
-                <i class="fa fa-leaf"></i> ORCID
+                <i class="fa-brands fa-orcid"></i> ORCID
               </a>
             
             

--- a/docs/people/index.html
+++ b/docs/people/index.html
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -355,6 +355,7 @@ Making any change will effect all the pages(not posts) -->
           
           
           
+          
         </ul>
       </div>
     </a>
@@ -390,6 +391,7 @@ document.addEventListener("DOMContentLoaded", function() {
         
   
         <ul class="team-social d-flex justify-content-center list-unstyled mb-0">
+          
           
           
           
@@ -437,6 +439,7 @@ document.addEventListener("DOMContentLoaded", function() {
           
           
           
+          
         </ul>
       </div>
     </a>
@@ -472,6 +475,7 @@ document.addEventListener("DOMContentLoaded", function() {
         
   
         <ul class="team-social d-flex justify-content-center list-unstyled mb-0">
+          
           
           
           
@@ -519,6 +523,7 @@ document.addEventListener("DOMContentLoaded", function() {
           
           
           
+          
         </ul>
       </div>
     </a>
@@ -554,6 +559,7 @@ document.addEventListener("DOMContentLoaded", function() {
         
   
         <ul class="team-social d-flex justify-content-center list-unstyled mb-0">
+          
           
           
           
@@ -615,6 +621,7 @@ document.addEventListener("DOMContentLoaded", function() {
           
           
           
+          
         </ul>
       </div>
     </a>
@@ -650,6 +657,7 @@ document.addEventListener("DOMContentLoaded", function() {
         
   
         <ul class="team-social d-flex justify-content-center list-unstyled mb-0">
+          
           
           
           

--- a/docs/people/kai-wanner/index.html
+++ b/docs/people/kai-wanner/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -336,6 +336,7 @@ galite.UA = 'UA-92266803-2';
         />
         
         <ul class="team-social profile-social">
+          
           
           
           

--- a/docs/people/keno-strotjohann/index.html
+++ b/docs/people/keno-strotjohann/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -337,15 +337,16 @@ galite.UA = 'UA-92266803-2';
         
         <ul class="team-social profile-social">
           
-          <li><a href="https://twitter.com/st_keno"><i class="fa fa-twitter-square fa"></i></a></li>
+          <li><a href="https://twitter.com/st_keno"><i class="fa-brands fa-twitter fa"></i></a></li>
           
           
-          <li><a href="https://github.com/kstrotjohann"><i class="fa fa-github-square fa"></i></a></li>
+          <li><a href="https://github.com/kstrotjohann"><i class="fa-brands fa-github fa"></i></a></li>
           
           
           
           
-          <li><a href="https://orcid.org/0009-0003-3675-3039"><i class="fa fa-leaf fa"></i></a></li>
+          
+          <li><a href="https://orcid.org/0009-0003-3675-3039"><i class="fa-brands fa-orcid fa"></i></a></li>
           
         </ul>
       </div>
@@ -404,7 +405,7 @@ galite.UA = 'UA-92266803-2';
           <div class="d-flex justify-content-center flex-wrap gap-2">
             
               <a href="https://orcid.org/0009-0003-3675-3039" class="btn btn-outline-info" style="color: #2c7eca; margin-right: 10px;" target="_blank" rel="noopener noreferrer">
-                <i class="fa fa-leaf"></i> ORCID
+                <i class="fa-brands fa-orcid"></i> ORCID
               </a>
             
             

--- a/docs/people/nadia-neuner-jehle/index.html
+++ b/docs/people/nadia-neuner-jehle/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -338,14 +338,15 @@ galite.UA = 'UA-92266803-2';
         <ul class="team-social profile-social">
           
           
-          <li><a href="https://github.com/nneune"><i class="fa fa-github-square fa"></i></a></li>
-          
-          
-          <li><a href="https://www.linkedin.com/in/nadia-neuner-jehle"><i class="fa fa-linkedin-square fa"></i></a></li>
+          <li><a href="https://github.com/nneune"><i class="fa-brands fa-github fa"></i></a></li>
           
           
           
-          <li><a href="https://orcid.org/0009-0001-6829-6448"><i class="fa fa-leaf fa"></i></a></li>
+          <li><a href="https://www.linkedin.com/in/nadia-neuner-jehle"><i class="fa-brands fa-linkedin-in fa"></i></a></li>
+          
+          
+          
+          <li><a href="https://orcid.org/0009-0001-6829-6448"><i class="fa-brands fa-orcid fa"></i></a></li>
           
         </ul>
       </div>
@@ -428,7 +429,7 @@ galite.UA = 'UA-92266803-2';
           <div class="d-flex justify-content-center flex-wrap gap-2">
             
               <a href="https://orcid.org/0009-0001-6829-6448" class="btn btn-outline-info" style="color: #2c7eca; margin-right: 10px;" target="_blank" rel="noopener noreferrer">
-                <i class="fa fa-leaf"></i> ORCID
+                <i class="fa-brands fa-orcid"></i> ORCID
               </a>
             
             

--- a/docs/people/nema-ahmed-alfaki/index.html
+++ b/docs/people/nema-ahmed-alfaki/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -336,6 +336,7 @@ galite.UA = 'UA-92266803-2';
         />
         
         <ul class="team-social profile-social">
+          
           
           
           

--- a/docs/people/nosihle-msomi/index.html
+++ b/docs/people/nosihle-msomi/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -337,17 +337,18 @@ galite.UA = 'UA-92266803-2';
         
         <ul class="team-social profile-social">
           
-          <li><a href="https://twitter.com/nosi_msomi"><i class="fa fa-twitter-square fa"></i></a></li>
+          <li><a href="https://twitter.com/nosi_msomi"><i class="fa-brands fa-twitter fa"></i></a></li>
           
           
-          <li><a href="https://github.com/Nosi-Msomi"><i class="fa fa-github-square fa"></i></a></li>
-          
-          
-          <li><a href="https://www.linkedin.com/in/nosihlesmsomi"><i class="fa fa-linkedin-square fa"></i></a></li>
+          <li><a href="https://github.com/Nosi-Msomi"><i class="fa-brands fa-github fa"></i></a></li>
           
           
           
-          <li><a href="https://orcid.org/0000-0003-0053-0928"><i class="fa fa-leaf fa"></i></a></li>
+          <li><a href="https://www.linkedin.com/in/nosihlesmsomi"><i class="fa-brands fa-linkedin-in fa"></i></a></li>
+          
+          
+          
+          <li><a href="https://orcid.org/0000-0003-0053-0928"><i class="fa-brands fa-orcid fa"></i></a></li>
           
         </ul>
       </div>
@@ -419,7 +420,7 @@ galite.UA = 'UA-92266803-2';
           <div class="d-flex justify-content-center flex-wrap gap-2">
             
               <a href="https://orcid.org/0000-0003-0053-0928" class="btn btn-outline-info" style="color: #2c7eca; margin-right: 10px;" target="_blank" rel="noopener noreferrer">
-                <i class="fa fa-leaf"></i> ORCID
+                <i class="fa-brands fa-orcid"></i> ORCID
               </a>
             
             

--- a/docs/people/sten-de-schrijver/index.html
+++ b/docs/people/sten-de-schrijver/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -336,6 +336,7 @@ galite.UA = 'UA-92266803-2';
         />
         
         <ul class="team-social profile-social">
+          
           
           
           

--- a/docs/projects/basel-wastewater/index.html
+++ b/docs/projects/basel-wastewater/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/projects/evd68/index.html
+++ b/docs/projects/evd68/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/projects/evs/index.html
+++ b/docs/projects/evs/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/projects/hcovs/index.html
+++ b/docs/projects/hcovs/index.html
@@ -50,7 +50,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -78,7 +78,7 @@
 </url>
 <url>
 <loc>https://hodcroftlab.github.io/hodcroftlab/about/</loc>
-<lastmod>2025-04-21T16:09:20+02:00</lastmod>
+<lastmod>2025-08-04T17:12:34+02:00</lastmod>
 </url>
 <url>
 <loc>https://hodcroftlab.github.io/hodcroftlab/collaborations/artic2/</loc>

--- a/docs/testimonials/index.html
+++ b/docs/testimonials/index.html
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 

--- a/docs/tools/index.html
+++ b/docs/tools/index.html
@@ -47,7 +47,7 @@
     <!-- Fontawesome Icons CSS -->
     <link
       rel="stylesheet"
-      href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.6.0/css/all.min.css"> -->
 
@@ -354,7 +354,7 @@ Making any change will effect all the pages(not posts) -->
 	
 		
 			<a href="https://github.com/hodcroftlab/evd68-converter" class="btn btn-outline-secondary" target="_blank" rel="noopener">
-			<i class="fa fa-github me-1"></i> View on GitHub
+			<i class="fa-brands fa-github me-1"></i> View on GitHub
 			</a>
 		
     </div>


### PR DESCRIPTION
Upgrades us from FontAwesome 4.7 to FontAwesome 6.5!

This also then replaces the names of icons that have been renamed in the meantime, so all icons links should work now.

In addition:
- removes Google+ share links on blogs (this doesn't exist anymore)
- adds Bluesky sharing option on blogs
- adds a user option to add a link for mastodon 